### PR TITLE
Correct the variable name in contribution markdown format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ image: <URL of the image to be displayed> (O)
 ---
 ```
 
-- Raise your PR a nd wait for it to get merged.
+- Raise your PR and wait for it to get merged.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,11 +27,11 @@ categories:
 url: <URL of the API>
 description: <A short description of API>
 free: <true if API is free else false>
-imageUrl: <URL of the image to be displayed> (O)
+image: <URL of the image to be displayed> (O)
 ---
 ```
 
-- Raise your PR and wait for it to get merged.
+- Raise your PR a nd wait for it to get merged.
 
 ---
 


### PR DESCRIPTION
Current contribution markdown is having variable name "imageURL" for api content. But in code we are accessing image url using "image" variable. 

So just to avoid correction while creating api content...changed the variable name. So one can directly copy-paste format and use it without changing variable name.

Attached code snippet ss.

**File** : src/components/ApiCard.tsx

![Screenshot from 2024-08-06 19-00-59](https://github.com/user-attachments/assets/77f29e1b-0ccb-4f7e-ba62-72a681758320)

 